### PR TITLE
`vroom_format()` handles empty data frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vroom (development version)
 
+* Fixed segfault when `vroom_format()` is given an empty data frame (#425)
+
 * Fixed a segfault that could occur when the final field of the final line is missing and the file also does not end in a newline (#429).
 
 * Fix recursive gc error that could occur during `vroom_write()` when `output_column()` generates an ALTREP vector (#389).

--- a/R/vroom_write.R
+++ b/R/vroom_write.R
@@ -126,7 +126,7 @@ vroom_format <- function(x, delim = "\t", eol = "\n", na = "NA", col_names = TRU
 
   stopifnot(is.data.frame(x))
 
-  if (length(x) == 0) {
+  if (NCOL(x) == 0) {
     return("")
   }
 

--- a/R/vroom_write.R
+++ b/R/vroom_write.R
@@ -124,6 +124,12 @@ vroom_format <- function(x, delim = "\t", eol = "\n", na = "NA", col_names = TRU
                          bom = FALSE,
                          num_threads = vroom_threads()) {
 
+  stopifnot(is.data.frame(x))
+
+  if (length(x) == 0) {
+    return("")
+  }
+
   quote <- match.arg(quote)
   escape <- match.arg(escape)
 

--- a/src/vroom_write.cc
+++ b/src/vroom_write.cc
@@ -322,11 +322,13 @@ std::vector<char> get_header(
       out.push_back(delim);
     }
   }
-  if (delim != '\0') {
-    out.pop_back();
-  }
-  for (auto c : eol) {
-    out.push_back(c);
+  if(out.size() != 0) {
+    if (delim != '\0') {
+      out.pop_back();
+    }
+    for (auto c : eol) {
+      out.push_back(c);
+    }
   }
   return out;
 }

--- a/tests/testthat/test-vroom_write.R
+++ b/tests/testthat/test-vroom_write.R
@@ -209,13 +209,15 @@ test_that("vroom_format handles empty data frames", {
   df <- data.frame(a = 1:2, b = 2:3)
   df <- df[0, ]
   expect_equal(vroom_format(df), "a\tb\n")
+})
 
+test_that("vroom_write() / vroom_read() roundtrips an empty data frame", {
   df <- tibble::tibble()
   t <- tempfile(fileext = ".csv")
   on.exit(unlink(t))
 
-  vroom::vroom_write(df, t)
-  expect_equal(vroom::vroom(t, col_types = list()), df)
+  vroom_write(df, t)
+  expect_equal(vroom(t, show_col_types = FALSE), df)
 })
 
 test_that("vroom_write(append = TRUE) works with R connections", {

--- a/tests/testthat/test-vroom_write.R
+++ b/tests/testthat/test-vroom_write.R
@@ -202,6 +202,11 @@ test_that("vroom_write equals the same thing as vroom_format", {
   expect_equal(readChar(tf, file.info(tf)$size), vroom_format(df))
 })
 
+test_that("vroom_format handles empty data frames", {
+  df <- data.frame()
+  expect_equal(vroom_format(df), "")
+})
+
 test_that("vroom_write(append = TRUE) works with R connections", {
   df <- data.frame(x = 1, y = 2)
   f <- tempfile(fileext = ".tsv.gz")

--- a/tests/testthat/test-vroom_write.R
+++ b/tests/testthat/test-vroom_write.R
@@ -209,6 +209,13 @@ test_that("vroom_format handles empty data frames", {
   df <- data.frame(a = 1:2, b = 2:3)
   df <- df[0, ]
   expect_equal(vroom_format(df), "a\tb\n")
+
+  df <- tibble::tibble()
+  t <- tempfile(fileext = ".csv")
+  on.exit(unlink(t))
+
+  vroom::vroom_write(df, t)
+  expect_equal(vroom::vroom(t, col_types = list()), df)
 })
 
 test_that("vroom_write(append = TRUE) works with R connections", {

--- a/tests/testthat/test-vroom_write.R
+++ b/tests/testthat/test-vroom_write.R
@@ -205,6 +205,10 @@ test_that("vroom_write equals the same thing as vroom_format", {
 test_that("vroom_format handles empty data frames", {
   df <- data.frame()
   expect_equal(vroom_format(df), "")
+
+  df <- data.frame(a = 1:2, b = 2:3)
+  df <- df[0, ]
+  expect_equal(vroom_format(df), "a\tb\n")
 })
 
 test_that("vroom_write(append = TRUE) works with R connections", {


### PR DESCRIPTION
Closes #425 

`vroom_format()` and `readr::format_csv()` return the empty string now.