### PR TITLE
Remove the width from the taylor gif

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -48,7 +48,7 @@ tbl <- tm %>% filter(type == "real", op == "read", reading_package %in% c("data.
 
 The fastest delimited reader for R, **`r filter(tbl, package == "vroom") %>% pull("throughput") %>% trimws()`**.
 
-<img src="https://raw.githubusercontent.com/r-lib/vroom/main/img/taylor.gif" align="right" width = "30%"/>
+<img src="https://raw.githubusercontent.com/r-lib/vroom/main/img/taylor.gif" align="right" />
 
 But that's impossible! How can it be [so fast](https://vroom.r-lib.org/articles/benchmarks.html)?
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://
 
 The fastest delimited reader for R, **1.23 GB/sec**.
 
-<img src="https://raw.githubusercontent.com/r-lib/vroom/main/img/taylor.gif" align="right" width = "30%"/>
+<img src="https://raw.githubusercontent.com/r-lib/vroom/main/img/taylor.gif" align="right" />
 
 But that’s impossible! How can it be [so
 fast](https://vroom.r-lib.org/articles/benchmarks.html)?


### PR DESCRIPTION
Having only 30% is making it look way to small on GitHub, and it seems
to still look right on the pkgdown site as well without an explicit
width.