### PR TITLE
Allow calling `problems()` on `.Last.value`

### DIFF
--- a/R/problems.R
+++ b/R/problems.R
@@ -16,7 +16,7 @@
 #'   - actual - What it actually found
 #'   - file - The file with the problem
 #' @export
-problems <- function(x, lazy = FALSE) {
+problems <- function(x = .Last.value, lazy = FALSE) {
   if (!isTRUE(lazy)) {
     vroom_materialize(x, replace = FALSE)
   }

--- a/R/problems.R
+++ b/R/problems.R
@@ -23,7 +23,7 @@ problems <- function(x = .Last.value, lazy = FALSE) {
 
   probs <- attr(x, "problems")
   if (typeof(probs) != "externalptr") {
-    rlang::abort("`x` must have a problems attribute that is an external pointer.\n  Is this object from readr and not vroom?")
+    rlang::abort("`x` must have a problems attribute that is an external pointer.\n  Is this object from first edition readr?")
   }
   probs <- vroom_errors_(probs)
   probs <- probs[!duplicated(probs), ]

--- a/R/problems.R
+++ b/R/problems.R
@@ -17,13 +17,19 @@
 #'   - file - The file with the problem
 #' @export
 problems <- function(x = .Last.value, lazy = FALSE) {
+  if(!inherits(x, "tbl_df")) {
+    cli::cli_abort(c("{.var x} must be a tibble.",
+                     "x" = "You've supplied a {typeof(x)}."))
+  }
+
   if (!isTRUE(lazy)) {
     vroom_materialize(x, replace = FALSE)
   }
 
   probs <- attr(x, "problems")
   if (typeof(probs) != "externalptr") {
-    rlang::abort("`x` must have a problems attribute that is an external pointer.\n  Is this object from first edition readr?")
+    cli::cli_abort(c("{.var x} must have a problems attribute that is an external pointer.",
+                 "i" = "Is this object from first edition readr?"))
   }
   probs <- vroom_errors_(probs)
   probs <- probs[!duplicated(probs), ]

--- a/man/problems.Rd
+++ b/man/problems.Rd
@@ -4,7 +4,7 @@
 \alias{problems}
 \title{Retrieve parsing problems}
 \usage{
-problems(x, lazy = FALSE)
+problems(x = .Last.value, lazy = FALSE)
 }
 \arguments{
 \item{x}{A data frame from \code{vroom::vroom()}.}

--- a/tests/testthat/test-problems.R
+++ b/tests/testthat/test-problems.R
@@ -170,3 +170,13 @@ test_that("can promote vroom parse warning to error", {
     )
   )
 })
+
+test_that("problems works with .Last.value", {
+  vroom(I("x,y\n1,2\n1,1.x\n"), col_types = "dd", altrep = FALSE)
+  probs <- problems()
+
+  expect_equal(probs$row, 3)
+  expect_equal(probs$col, 2)
+  expect_equal(probs$expected, "a double")
+  expect_equal(probs$actual, "1.x")
+})


### PR DESCRIPTION
Currently, readr allows `readr::problems()` to be called on `.Last.value` without arguments. For consistency, we should bring over this feature to vroom. Since we are updating `vroom::problems()` we also are modernizing the warning message some.