### PR TITLE
Don’t overwrite existing file if appending an empty data frame

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vroom (development version)
 
+* `vroom_write(append = TRUE)` does not modify an existing file when appending an empty data frame. In particular, it does not overwrite (delete) the existing contents of that file (https://github.com/tidyverse/readr/issues/1408, #451).
+
 * `vroom::problems()` now defaults to `.Last.value` for its primary input, similar to how `readr::problems()` works (#443).
 
 * The warning that indicates the existence of parsing problems has been improved, which should make it easier for the user to follow-up (https://github.com/tidyverse/readr/issues/1322).

--- a/R/vroom_write.R
+++ b/R/vroom_write.R
@@ -58,10 +58,9 @@ vroom_write <- function(x, file, delim = '\t', eol = "\n", na = "NA", col_names 
   # Standardise path returns a list, but we will only ever have 1 output file.
   file <- standardise_one_path(file, write = TRUE)
 
-  # If there are no columns in the data frame and we aren't appending
-  # just create an empty file and return
-  if (NCOL(x) == 0 && !append) {
-    if (!inherits(file, "connection")) {
+  # If there are no columns in the data frame then return early
+  if (NCOL(x) == 0) {
+    if (!append && !inherits(file, "connection")) {
       file.create(file)
     }
     return(invisible(input))

--- a/R/vroom_write.R
+++ b/R/vroom_write.R
@@ -58,8 +58,9 @@ vroom_write <- function(x, file, delim = '\t', eol = "\n", na = "NA", col_names 
   # Standardise path returns a list, but we will only ever have 1 output file.
   file <- standardise_one_path(file, write = TRUE)
 
-  # If there are no columns in the data frame, just create an empty file and return
-  if (NCOL(x) == 0) {
+  # If there are no columns in the data frame and we aren't appending
+  # just create an empty file and return
+  if (NCOL(x) == 0 && !append) {
     if (!inherits(file, "connection")) {
       file.create(file)
     }

--- a/tests/testthat/test-vroom_write.R
+++ b/tests/testthat/test-vroom_write.R
@@ -312,10 +312,10 @@ test_that("vroom_write() does not overwrite file when appending empty data frame
   data <- tibble::tibble(a = "1", b = "2", c = "3")
 
   vroom_write(data, file = tf)
-  first_write <- vroom(tf, show_col_types = FALSE)
+  first_write <- vroom(tf, altrep = FALSE, show_col_types = FALSE)
 
   vroom_write(data.frame(), file = tf, append = TRUE)
-  second_write <- vroom(tf, show_col_types = FALSE)
+  second_write <- vroom(tf, altrep = FALSE, show_col_types = FALSE)
 
   expect_equal(first_write, second_write)
 })

--- a/tests/testthat/test-vroom_write.R
+++ b/tests/testthat/test-vroom_write.R
@@ -320,8 +320,7 @@ test_that("vroom_write() does not overwrite file when appending empty data frame
 
   expect_equal(
     vroom_lines(tf,
-      altrep = FALSE,
-      skip_empty_rows = FALSE
+      altrep = FALSE
     ),
     c("a,b,c", "1,2,3")
   )

--- a/tests/testthat/test-vroom_write.R
+++ b/tests/testthat/test-vroom_write.R
@@ -318,7 +318,5 @@ test_that("vroom_write() does not overwrite file when appending empty data frame
   vroom_write(data, file = tf, delim = ",")
   vroom_write(data.frame(), file = tf, append = TRUE, delim = ",")
 
-  expect_equal(vroom_lines(tf,
-                           altrep = FALSE),
-               c("a,b,c", "1,2,3"))
+  expect_equal(vroom_lines(tf, altrep = FALSE), c("a,b,c", "1,2,3"))
 })

--- a/tests/testthat/test-vroom_write.R
+++ b/tests/testthat/test-vroom_write.R
@@ -318,10 +318,7 @@ test_that("vroom_write() does not overwrite file when appending empty data frame
   vroom_write(data, file = tf, delim = ",")
   vroom_write(data.frame(), file = tf, append = TRUE, delim = ",")
 
-  expect_equal(
-    vroom_lines(tf,
-      altrep = FALSE
-    ),
-    c("a,b,c", "1,2,3")
-  )
+  expect_equal(vroom_lines(tf,
+                           altrep = FALSE),
+               c("a,b,c", "1,2,3"))
 })

--- a/tests/testthat/test-vroom_write.R
+++ b/tests/testthat/test-vroom_write.R
@@ -309,13 +309,15 @@ test_that("na argument modifies how missing values are written", {
 
 test_that("vroom_write() does not overwrite file when appending empty data frame", {
   tf <- withr::local_tempfile()
-  data <- tibble::tibble(a = "1", b = "2", c = "3")
+  data <- tibble::tibble(a = "1",
+                         b = "2",
+                         c = "3")
 
-  vroom_write(data, file = tf)
-  first_write <- vroom(tf, altrep = FALSE, show_col_types = FALSE)
+  vroom_write(data, file = tf, delim = ",")
+  vroom_write(data.frame(), file = tf, append = TRUE, delim = ",")
 
-  vroom_write(data.frame(), file = tf, append = TRUE)
-  second_write <- vroom(tf, altrep = FALSE, show_col_types = FALSE)
-
-  expect_equal(first_write, second_write)
+  expect_equal(vroom_lines(tf,
+                           altrep = FALSE,
+                           skip_empty_rows = FALSE),
+               c("a,b,c", "1,2,3"))
 })

--- a/tests/testthat/test-vroom_write.R
+++ b/tests/testthat/test-vroom_write.R
@@ -309,15 +309,20 @@ test_that("na argument modifies how missing values are written", {
 
 test_that("vroom_write() does not overwrite file when appending empty data frame", {
   tf <- withr::local_tempfile()
-  data <- tibble::tibble(a = "1",
-                         b = "2",
-                         c = "3")
+  data <- tibble::tibble(
+    a = "1",
+    b = "2",
+    c = "3"
+  )
 
   vroom_write(data, file = tf, delim = ",")
   vroom_write(data.frame(), file = tf, append = TRUE, delim = ",")
 
-  expect_equal(vroom_lines(tf,
-                           altrep = FALSE,
-                           skip_empty_rows = FALSE),
-               c("a,b,c", "1,2,3"))
+  expect_equal(
+    vroom_lines(tf,
+      altrep = FALSE,
+      skip_empty_rows = FALSE
+    ),
+    c("a,b,c", "1,2,3")
+  )
 })

--- a/tests/testthat/test-vroom_write.R
+++ b/tests/testthat/test-vroom_write.R
@@ -306,3 +306,16 @@ test_that("na argument modifies how missing values are written", {
   df <- data.frame(x = c(NA, "x"), y = c(1, 2))
   expect_equal(vroom_format(df, ",", na = "None"), "x,y\nNone,1\nx,2\n")
 })
+
+test_that("vroom_write() does not overwrite file when appending empty data frame", {
+  tf <- withr::local_tempfile()
+  data <- tibble::tibble(a = "1", b = "2", c = "3")
+
+  vroom_write(data, file = tf)
+  first_write <- vroom(tf, show_col_types = FALSE)
+
+  vroom_write(data.frame(), file = tf, append = TRUE)
+  second_write <- vroom(tf, show_col_types = FALSE)
+
+  expect_equal(first_write, second_write)
+})


### PR DESCRIPTION
Fixes tidyverse/readr#1408

Previously, if `vroom_write()` was supplied an empty data frame, vroom created an empty file without checking the value of `append`. But this meant data from the file could be deleted such as in this case.

``` 
library(vroom)
tf <- withr::local_tempfile()
data <- tibble::tibble(a = "1", b = "2", c = "3")

vroom_write(data, file = tf)
vroom(tf, show_col_types = FALSE)
#> # A tibble: 1 × 3
#>       a     b     c
#>   <dbl> <dbl> <dbl>
#> 1     1     2     3

vroom_write(data.frame(), file = tf, append = TRUE)
vroom(tf, show_col_types = FALSE)
#> # A tibble: 0 × 0
```

<sup>Created on 2022-07-15 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1.9000)</sup>
