### PR TITLE
Update test for `unwind::protect` error in `vroom_errors::warn_for_errors()`

### DIFF
--- a/tests/testthat/test-problems.R
+++ b/tests/testthat/test-problems.R
@@ -158,9 +158,9 @@ test_that("can promote vroom parse warning to error", {
 
     # Trigger vroom parse warning while inside R's internal C code for `[` and ensure it doesn't crash R.
     # `[` -> R's C function `do_subset()` -> ALTREP calls `vroom::real_Elt()` -> `vroom::warn_for_errors()`
-    # `warn_for_errors()` warns with base R's machinery rather than cpp11's to avoid calling
-    # `unwind_protect()` (which throws on longjmp, i.e. on `abort()`) while inside R's internal
-    # C code (which doesn't catch C++ exceptions).
+    # To avoid calling `cpp11::unwind_protect()` (which throws on longjmp, i.e. on `abort()`) while inside
+    # R's internal C code (which doesn't catch C++ exceptions), `vroom::warn_for_errors()` warns
+    # with base R's machinery rather than cpp11's
     # https://github.com/r-lib/cpp11/issues/274
     # https://github.com/tidyverse/vroom/pull/441#discussion_r883611090
     x$a[1]

--- a/tests/testthat/test-problems.R
+++ b/tests/testthat/test-problems.R
@@ -150,13 +150,15 @@ test_that("problems return the proper row number", {
 test_that("can promote vroom parse warning to error", {
   make_warning <- function() {
     x <- vroom(
-      I("a,b\n1.0,x\n"),
+      I("a\nx\n"),
       delim = ",",
-      col_types = "dd"
+      col_types = "d",
+      altrep = TRUE
     )
 
-    # Warning happens at print time so force a print
-    print(x)
+    # trigger the warning using R's internal [ code
+    # https://github.com/r-lib/cpp11/issues/274
+    x$a[1]
   }
 
   expect_error(

--- a/tests/testthat/test-problems.R
+++ b/tests/testthat/test-problems.R
@@ -156,7 +156,7 @@ test_that("can promote vroom parse warning to error", {
       altrep = TRUE
     )
 
-    # trigger the warning using R's internal [ code
+    # do something to trigger the warning using R's internal C code
     # https://github.com/r-lib/cpp11/issues/274
     x$a[1]
   }

--- a/tests/testthat/test-problems.R
+++ b/tests/testthat/test-problems.R
@@ -156,8 +156,13 @@ test_that("can promote vroom parse warning to error", {
       altrep = TRUE
     )
 
-    # do something to trigger the warning using R's internal C code
+    # Trigger vroom parse warning while inside R's internal C code for `[` and ensure it doesn't crash R.
+    # `[` -> R's C function `do_subset()` -> ALTREP calls `vroom::real_Elt()` -> `vroom::warn_for_errors()`
+    # `warn_for_errors()` warns with base R's machinery rather than cpp11's to avoid calling
+    # `unwind_protect()` (which throws on longjmp, i.e. on `abort()`) while inside R's internal
+    # C code (which doesn't catch C++ exceptions).
     # https://github.com/r-lib/cpp11/issues/274
+    # https://github.com/tidyverse/vroom/pull/441#discussion_r883611090
     x$a[1]
   }
 

--- a/tests/testthat/test-problems.R
+++ b/tests/testthat/test-problems.R
@@ -160,7 +160,7 @@ test_that("can promote vroom parse warning to error", {
     # `[` -> R's C function `do_subset()` -> ALTREP calls `vroom::real_Elt()` -> `vroom::warn_for_errors()`
     # To avoid calling `cpp11::unwind_protect()` (which throws on longjmp, i.e. on `abort()`) while inside
     # R's internal C code (which doesn't catch C++ exceptions), `vroom::warn_for_errors()` warns
-    # with base R's machinery rather than cpp11's
+    # with cli called from base R's machinery, rather than from `cpp11::package()`
     # https://github.com/r-lib/cpp11/issues/274
     # https://github.com/tidyverse/vroom/pull/441#discussion_r883611090
     x$a[1]


### PR DESCRIPTION
Fixes #445 


This might be a bit redundant/circular, but I'm going to relink @DavisVaughan issue post about this because I found it really useful for refreshing my memory on the problem

https://github.com/r-lib/cpp11/issues/274