### PR TITLE
fix issue with empty date and datetime columns

### DIFF
--- a/R/col_types.R
+++ b/R/col_types.R
@@ -515,10 +515,10 @@ collector_value.collector_logical <- function(x, ...) { logical() }
 collector_value.collector_factor <- function(x, ...) { factor() }
 
 #' @export
-collector_value.collector_datetime <- function(x, ...) { as.POSIXct(double()) }
+collector_value.collector_datetime <- function(x, ...) { as.POSIXct(character()) }
 
 #' @export
-collector_value.collector_date <- function(x, ...) { as.Date(double()) }
+collector_value.collector_date <- function(x, ...) { as.Date(character()) }
 
 #' @export
 collector_value.collector_time <- function(x, ...) { hms::hms() }

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -514,11 +514,15 @@ collector_value.collector_logical <- function(x, ...) { logical() }
 #' @export
 collector_value.collector_factor <- function(x, ...) { factor() }
 
+# the more obvious as.POSIXct(double()) doesn't work on R < 4.0
+# https://github.com/tidyverse/vroom/issues/453
 #' @export
-collector_value.collector_datetime <- function(x, ...) { as.POSIXct(character()) }
+collector_value.collector_datetime <- function(x, ...) { vctrs::vec_ptype(Sys.time()) }
 
+# the more obvious as.Date(double()) doesn't work on R < 4.0
+# and again: https://github.com/tidyverse/vroom/issues/453
 #' @export
-collector_value.collector_date <- function(x, ...) { as.Date(character()) }
+collector_value.collector_date <- function(x, ...) { vctrs::vec_ptype(Sys.Date()) }
 
 #' @export
 collector_value.collector_time <- function(x, ...) { hms::hms() }

--- a/tests/testthat/test-vroom.R
+++ b/tests/testthat/test-vroom.R
@@ -882,3 +882,14 @@ writeBin(charToRaw("foo,bar
   expect_equal(z, x)
 })
 
+test_that("vroom can read a date column with no data and skip 1", {
+  test_vroom("date\n", delim = ",", col_names = 'date', col_types = 'D', skip = 1,
+             equals = tibble::tibble(date = as.Date(character()))
+  )
+})
+
+test_that("vroom can read a datetime column with no data and skip 1", {
+  test_vroom("dt\n", delim = ",", col_names = 'dt', col_types = 'T', skip = 1,
+             equals = tibble::tibble(dt = as.POSIXct(character()))
+  )
+})

--- a/tests/testthat/test-vroom.R
+++ b/tests/testthat/test-vroom.R
@@ -882,12 +882,14 @@ writeBin(charToRaw("foo,bar
   expect_equal(z, x)
 })
 
+# https://github.com/tidyverse/vroom/issues/453
 test_that("vroom can read a date column with no data and skip 1", {
   test_vroom("date\n", delim = ",", col_names = 'date', col_types = 'D', skip = 1,
              equals = tibble::tibble(date = as.Date(character()))
   )
 })
 
+# https://github.com/tidyverse/vroom/issues/453
 test_that("vroom can read a datetime column with no data and skip 1", {
   test_vroom("dt\n", delim = ",", col_names = 'dt', col_types = 'T', skip = 1,
              equals = tibble::tibble(dt = as.POSIXct(character()))


### PR DESCRIPTION
Fixes #453

In older versions of R, like 3.6.3, there is an error when reading an empty date or date-time column with skip = 1.

```
vroom::vroom(I('date\n'), col_names = 'date', col_types = 'D', skip = 1L)
Error in as.Date.numeric(double()) : 'origin' must be supplied
Calls: <Anonymous> ... collector_value.collector_date -> as.Date -> as.Date.numeric
```
```
vroom::vroom(I('dt\n'), col_names = 'dt', col_types = 'T', skip = 1L)
Error in as.POSIXct.numeric(double()) : 'origin' must be supplied
Calls: <Anonymous> ... collector_value.collector_datetime -> as.POSIXct -> as.POSIXct.numeric
```

This commit fixes the error by using a character() vector instead of a double() vector.