### PR TITLE
Roll the ubuntu version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,14 +31,14 @@ jobs:
           - {os: windows-latest, r: '3.6'}
 
           # Use older ubuntu to maximise backward compatibility
-          - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-18.04,   r: 'release'}
-          - {os: ubuntu-18.04,   r: 'oldrel-1'}
-          - {os: ubuntu-18.04,   r: 'oldrel-2'}
-          - {os: ubuntu-18.04,   r: 'oldrel-3'}
-          - {os: ubuntu-18.04,   r: 'oldrel-4'}
+          - {os: ubuntu-20.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-20.04,   r: 'release'}
+          - {os: ubuntu-20.04,   r: 'oldrel-1'}
+          - {os: ubuntu-20.04,   r: 'oldrel-2'}
+          - {os: ubuntu-20.04,   r: 'oldrel-3'}
+          - {os: ubuntu-20.04,   r: 'oldrel-4'}
           # Check with a non-UTF-8 encoding
-          - {os: ubuntu-18.04,   r: 'release', cran: "https://demo.rstudiopm.com/all/__linux__/bionic/latest", locale: 'en_US.ISO-8859-1'}
+          - {os: ubuntu-20.04,   r: 'release', cran: "https://demo.rstudiopm.com/all/__linux__/focal/latest", locale: 'en_US.ISO-8859-1'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/debug.yaml
+++ b/.github/workflows/debug.yaml
@@ -4,12 +4,12 @@ on:
       os:
         description: 'Which operating system to debug on'
         required: true
-        default: 'ubuntu-18.04'
+        default: 'ubuntu-20.04'
         type: choice
         options:
         - macOS-latest
         - windows-latest
-        - ubuntu-18.04
+        - ubuntu-20.04
       r_version:
         description: 'Which R version to debug on'
         required: true


### PR DESCRIPTION
This is about aligning to GitHub's posture towards Ubuntu versions.

In GHA, we're starting to see this for vroom:

> The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002

We deliberately use an "old-ish" Ubuntu version for `R-CMD-check` workflow, but I think it's time to roll forward.