### PR TITLE
Include `id` column in `col_select` by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # vroom (development version)
 
+* `vroom(col_select=)` now handles column selection by numeric position when `id` column is provided (#455)
+
+* `vroom(id=)` now included in `col_select` by default, when provided (#416)
+
 * `vroom_write(append = TRUE)` does not modify an existing file when appending an empty data frame. In particular, it does not overwrite (delete) the existing contents of that file (https://github.com/tidyverse/readr/issues/1408, #451).
 
 * `vroom::problems()` now defaults to `.Last.value` for its primary input, similar to how `readr::problems()` works (#443).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * `vroom(col_select=)` now handles column selection by numeric position when `id` column is provided (#455)
 
-* `vroom(id=)` now included in `col_select` by default, when provided (#416)
+* `vroom(id = "path", col_select = a:c)` is treated like `vroom(id = "path", col_select = c(path, a:c))`. If an `id` column is provided, it is automatically included in the output (#416).
 
 * `vroom_write(append = TRUE)` does not modify an existing file when appending an empty data frame. In particular, it does not overwrite (delete) the existing contents of that file (https://github.com/tidyverse/readr/issues/1408, #451).
 

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -360,9 +360,10 @@ vroom_select <- function(x, col_select, id) {
   # reorder and rename columns
   if (inherits(col_select, "quosures") || !rlang::quo_is_null(col_select)) {
     if (inherits(col_select, "quosures")) {
-      vars <- tidyselect::vars_select(c(id, names(spec(x)$cols)), !!!col_select)
+      vars <- tidyselect::vars_select(c(names(spec(x)$cols), id), !!!col_select)
     } else {
-      vars <- tidyselect::vars_select(c(id, names(spec(x)$cols)), !!col_select)
+      vars <- tidyselect::vars_select(c(names(spec(x)$cols), id), !!col_select)
+    }
     if (!is.null(id) && !id %in% vars) {
       names(id) <- id
       vars <- c(id, vars)

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -363,6 +363,9 @@ vroom_select <- function(x, col_select, id) {
       vars <- tidyselect::vars_select(c(id, names(spec(x)$cols)), !!!col_select)
     } else {
       vars <- tidyselect::vars_select(c(id, names(spec(x)$cols)), !!col_select)
+    if (!is.null(id) && !id %in% vars) {
+      names(id) <- id
+      vars <- c(id, vars)
     }
     # This can't be just names(x) as we need to have skipped
     # names as well to pass to vars_select()

--- a/R/vroom.R
+++ b/R/vroom.R
@@ -77,7 +77,7 @@ NULL
 #' vroom(input_file, col_select = starts_with("d"))
 #'
 #' # You can also rename specific columns
-#' vroom(input_file, col_select = list(car = model, everything()))
+#' vroom(input_file, col_select = c(car = model, everything()))
 #'
 #' # Column types --------------------------------------------------------------
 #' # By default, vroom guesses the columns types, looking at 1000 rows

--- a/R/vroom.R
+++ b/R/vroom.R
@@ -20,7 +20,7 @@ NULL
 #'   default, no variable will be created.
 #' @param col_select Columns to include in the results. You can use the same
 #'   mini-language as `dplyr::select()` to refer to the columns by name. Use
-#'   `c()` or `list()` to use more than one selection expression. Although this
+#'   `c()` to use more than one selection expression. Although this
 #'   usage is less common, `col_select` also accepts a numeric column index. See
 #'   [`?tidyselect::language`][tidyselect::language] for full details on the
 #'   selection language.

--- a/man/vroom.Rd
+++ b/man/vroom.Rd
@@ -86,7 +86,7 @@ set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).
 
 \item{col_select}{Columns to include in the results. You can use the same
 mini-language as \code{dplyr::select()} to refer to the columns by name. Use
-\code{c()} or \code{list()} to use more than one selection expression. Although this
+\code{c()} to use more than one selection expression. Although this
 usage is less common, \code{col_select} also accepts a numeric column index. See
 \code{\link[tidyselect:language]{?tidyselect::language}} for full details on the
 selection language.}

--- a/man/vroom.Rd
+++ b/man/vroom.Rd
@@ -203,7 +203,7 @@ vroom(input_file, col_select = c(1, 3, 11))
 vroom(input_file, col_select = starts_with("d"))
 
 # You can also rename specific columns
-vroom(input_file, col_select = list(car = model, everything()))
+vroom(input_file, col_select = c(car = model, everything()))
 
 # Column types --------------------------------------------------------------
 # By default, vroom guesses the columns types, looking at 1000 rows

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -3,7 +3,7 @@ test_that("col_select works", {
 
   expect_equal(colnames(vroom(vroom_example("mtcars.csv"), col_select = 1:3, col_types = list())), c("model", "mpg", "cyl"))
 
-  expect_equal(colnames(vroom(vroom_example("mtcars.csv"), col_select = list(1, 5, 7), col_types = list())), c("model", "hp", "wt"))
+  expect_equal(colnames(vroom(vroom_example("mtcars.csv"), col_select = c(1, 5, 7), col_types = list())), c("model", "hp", "wt"))
 
   expect_equal(colnames(vroom(vroom_example("mtcars.csv"), col_select = c("model", "hp", "wt"), col_types = list())), c("model", "hp", "wt"))
 
@@ -29,7 +29,7 @@ test_that("col_select with negations works", {
 })
 
 test_that("col_select with renaming", {
-  expect_equal(colnames(vroom(vroom_example("mtcars.csv"), col_select = list(car = model, everything()), col_types = list())),
+  expect_equal(colnames(vroom(vroom_example("mtcars.csv"), col_select = c(car = model, everything()), col_types = list())),
     c("car", "mpg", "cyl", "disp", "hp", "drat", "wt", "qsec", "vs", "am", "gear", "carb")
   )
 })
@@ -43,7 +43,7 @@ test_that("col_select works with vroom_fwf", {
       vroom_fwf(
         test_path("fwf-trailing.txt"),
         spec,
-        col_select = list(foo = X1, X2),
+        col_select = c(foo = X1, X2),
         col_types = list()
       )
     ),
@@ -54,31 +54,31 @@ test_that("col_select works with vroom_fwf", {
 test_that("col_select can select the id column", {
 
   expect_named(
-    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(model, mpg, path), col_types = list()),
+    vroom(vroom_example("mtcars.csv"), id = "path", col_select = c(model, mpg, path), col_types = list()),
     c("model", "mpg", "path")
   )
 
   expect_named(
-    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(path, model, mpg), col_types = list()),
+    vroom(vroom_example("mtcars.csv"), id = "path", col_select = c(path, model, mpg), col_types = list()),
     c("path", "model", "mpg")
   )
 })
 
 test_that("id column is automatically included in col_select (#416)", {
   expect_named(
-    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(model, mpg), show_col_types = FALSE),
+    vroom(vroom_example("mtcars.csv"), id = "path", col_select = c(model, mpg), show_col_types = FALSE),
     c("path", "model", "mpg")
   )
 })
 
 test_that("referencing columns by position in col_select works with id column (#455)", {
   expect_named(
-    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(1:3), show_col_types = FALSE),
+    vroom(vroom_example("mtcars.csv"), id = "path", col_select = c(1:3), show_col_types = FALSE),
     c("path", "model", "mpg", "cyl")
   )
 
   expect_named(
-    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(1:3,6:8), show_col_types = FALSE),
+    vroom(vroom_example("mtcars.csv"), id = "path", col_select = c(1:3,6:8), show_col_types = FALSE),
     c("path", "model", "mpg", "cyl", "drat", "wt", "qsec")
   )
 })

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -66,19 +66,19 @@ test_that("col_select can select the id column", {
 
 test_that("id column is automatically included in col_select (#416)", {
   expect_named(
-    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(model, mpg)),
+    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(model, mpg), show_col_types = FALSE),
     c("path", "model", "mpg")
   )
 })
 
 test_that("referencing columns by position in col_select works with id column (#455)", {
   expect_named(
-    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(1:3)),
+    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(1:3), show_col_types = FALSE),
     c("path", "model", "mpg", "cyl")
   )
 
   expect_named(
-    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(1:3,6:8)),
+    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(1:3,6:8), show_col_types = FALSE),
     c("path", "model", "mpg", "cyl", "drat", "wt", "qsec")
   )
 })

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -64,7 +64,7 @@ test_that("col_select can select the id column", {
   )
 })
 
-test_that("id column not required in col_select (#416)", {
+test_that("id column is automatically included in col_select (#416)", {
   expect_named(
     vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(model, mpg)),
     c("path", "model", "mpg")

--- a/tests/testthat/test-select.R
+++ b/tests/testthat/test-select.R
@@ -64,6 +64,25 @@ test_that("col_select can select the id column", {
   )
 })
 
+test_that("id column not required in col_select (#416)", {
+  expect_named(
+    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(model, mpg)),
+    c("path", "model", "mpg")
+  )
+})
+
+test_that("referencing columns by position in col_select works with id column (#455)", {
+  expect_named(
+    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(1:3)),
+    c("path", "model", "mpg", "cyl")
+  )
+
+  expect_named(
+    vroom(vroom_example("mtcars.csv"), id = "path", col_select = list(1:3,6:8)),
+    c("path", "model", "mpg", "cyl", "drat", "wt", "qsec")
+  )
+})
+
 test_that("col_select works with col_names = FALSE", {
   res <- vroom(I("foo\tbar\n1\t2\n"), col_names = FALSE, col_select = 1, col_types = list())
   expect_equal(res[[1]], c("foo", "1"))

--- a/vignettes/vroom.Rmd
+++ b/vignettes/vroom.Rmd
@@ -154,7 +154,7 @@ vroom(file, col_select = starts_with("d"))
 ```
 - You can also rename columns
 ```{r}
-vroom(file, col_select = list(car = model, everything()))
+vroom(file, col_select = c(car = model, everything()))
 ```
 
 ## Reading fixed width files


### PR DESCRIPTION
Fixes #416, Fixes #455 

The `id` column now does not have to be included in `col_select` (but still can be).

``` r
out1 <- glue::glue("a,b,c,d
               1,2,3,4")
out2 <- glue::glue("a,b,c,d
               5,6,7,8")

tf1 <- withr::local_tempfile(fileext = ".csv", lines = out1)
tf2 <- withr::local_tempfile(fileext = ".csv", lines = out2)

# don't need to provide the id column and
vroom(
  c(tf1, tf2),
  id = "source",
  col_select = c("a", "c"),
  show_col_types = FALSE
)
#> # A tibble: 2 × 3
#>   source                  a     c
#>   <chr>               <dbl> <dbl>
#> 1 /var/folders/4g/9j…     1     3
#> 2 /var/folders/4g/9j…     5     7

# but you still have the option to include it
vroom(
  c(tf1, tf2),
  id = "source",
  col_select = c("a", "c", "source"),
  show_col_types = FALSE
)
#> # A tibble: 2 × 3
#>       a     c source             
#>   <dbl> <dbl> <chr>              
#> 1     1     3 /var/folders/4g/9j…
#> 2     5     7 /var/folders/4g/9j…
```

This PR also fixes a bug when providing numeric column positions to `col_select` when the `id` column was provided. Previously, when indexing columns, indexing started at `id` rather than the first column position making it impossible to select some column positions numerically.

``` r
library(vroom)
out1 <- glue::glue("a,b,c,d
               1,2,3,4")
out2 <- glue::glue("a,b,c,d
               5,6,7,8")

tf1 <- withr::local_tempfile(fileext = ".csv", lines = out1)
tf2 <- withr::local_tempfile(fileext = ".csv", lines = out2)

vroom(
  c(tf1, tf2),
  id = "source",
  col_select = c(1:3),
  show_col_types = FALSE
)
#> # A tibble: 2 × 3
#>   source                                                                 a     b
#>   <chr>                                                              <dbl> <dbl>
#> 1 /var/folders/4g/9jcx0hbd6r92152m0qrq64yw0000gn/T//Rtmp8bp0zR/file…     1     2
#> 2 /var/folders/4g/9jcx0hbd6r92152m0qrq64yw0000gn/T//Rtmp8bp0zR/file…     5     6
```

Numeric positions now relate only to the original data and the id column is included by default.

``` r
out1 <- glue::glue("a,b,c,d
               1,2,3,4")
out2 <- glue::glue("a,b,c,d
               5,6,7,8")

tf1 <- withr::local_tempfile(fileext = ".csv", lines = out1)
tf2 <- withr::local_tempfile(fileext = ".csv", lines = out2)

vroom(
  c(tf1, tf2),
  id = "source",
  col_select = c(1:3),
  show_col_types = FALSE
)
#> # A tibble: 2 × 4
#>   source            a     b     c
#>   <chr>         <dbl> <dbl> <dbl>
#> 1 /var/folders…     1     2     3
#> 2 /var/folders…     5     6     7
```