### PR TITLE
Pass cli bullets to lifecycle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ Imports:
     crayon,
     glue,
     hms,
-    lifecycle,
+    lifecycle (>= 1.0.3),
     methods,
     rlang (>= 0.4.2),
     stats,

--- a/R/cpp11.R
+++ b/R/cpp11.R
@@ -28,18 +28,6 @@ convert_connection <- function(in_con, out_con, from, to) {
   .Call(`_vroom_convert_connection`, in_con, out_con, from, to)
 }
 
-vroom_ <- function(inputs, delim, quote, trim_ws, escape_double, escape_backslash, comment, skip_empty_rows, skip, n_max, progress, col_names, col_types, col_select, name_repair, id, na, locale, guess_max, num_threads, altrep) {
-  .Call(`_vroom_vroom_`, inputs, delim, quote, trim_ws, escape_double, escape_backslash, comment, skip_empty_rows, skip, n_max, progress, col_names, col_types, col_select, name_repair, id, na, locale, guess_max, num_threads, altrep)
-}
-
-has_trailing_newline <- function(filename) {
-  .Call(`_vroom_has_trailing_newline`, filename)
-}
-
-vroom_rle <- function(input) {
-  .Call(`_vroom_vroom_rle`, input)
-}
-
 utctime_ <- function(year, month, day, hour, min, sec, psec) {
   .Call(`_vroom_utctime_`, year, month, day, hour, min, sec, psec)
 }
@@ -66,4 +54,16 @@ vroom_write_connection_ <- function(input, con, delim, eol, na_str, col_names, o
 
 vroom_format_ <- function(input, delim, eol, na_str, col_names, append, options, num_threads, progress, buf_lines) {
   .Call(`_vroom_vroom_format_`, input, delim, eol, na_str, col_names, append, options, num_threads, progress, buf_lines)
+}
+
+vroom_ <- function(inputs, delim, quote, trim_ws, escape_double, escape_backslash, comment, skip_empty_rows, skip, n_max, progress, col_names, col_types, col_select, name_repair, id, na, locale, guess_max, num_threads, altrep) {
+  .Call(`_vroom_vroom_`, inputs, delim, quote, trim_ws, escape_double, escape_backslash, comment, skip_empty_rows, skip, n_max, progress, col_names, col_types, col_select, name_repair, id, na, locale, guess_max, num_threads, altrep)
+}
+
+has_trailing_newline <- function(filename) {
+  .Call(`_vroom_has_trailing_newline`, filename)
+}
+
+vroom_rle <- function(input) {
+  .Call(`_vroom_vroom_rle`, input)
 }

--- a/R/path.R
+++ b/R/path.R
@@ -47,14 +47,14 @@ standardise_path <- function(path) {
 
     if (any(grepl("\n", path))) {
       lifecycle::deprecate_soft("1.5.0", "vroom(file = 'must use `I()` for literal data')",
-        details = glue::glue('
-
-          # Bad:
-          vroom("foo\\nbar\\n")
-
-          # Good:
-          vroom(I("foo\\nbar\\n"))
-        ')
+        details = c(
+          "",
+          "# Bad:",
+          "vroom(\"foo\\nbar\\n\")",
+          "",
+          "# Good:",
+          "vroom(I(\"foo\\nbar\\n\"))"
+        )
       )
       return(list(chr_to_file(path, envir = parent.frame())))
     }

--- a/R/path.R
+++ b/R/path.R
@@ -21,7 +21,7 @@ reencode_file <- function(path, encoding) {
 }
 
 # These functions adapted from https://github.com/tidyverse/readr/blob/192cb1ca5c445e359f153d2259391e6d324fd0a2/R/source.R
-standardise_path <- function(path, user_env = caller_env(2)) {
+standardise_path <- function(path, user_env = rlang::caller_env(2)) {
   if (is.raw(path)) {
     return(list(rawConnection(path, "rb")))
   }

--- a/R/path.R
+++ b/R/path.R
@@ -21,7 +21,7 @@ reencode_file <- function(path, encoding) {
 }
 
 # These functions adapted from https://github.com/tidyverse/readr/blob/192cb1ca5c445e359f153d2259391e6d324fd0a2/R/source.R
-standardise_path <- function(path) {
+standardise_path <- function(path, user_env = caller_env(2)) {
   if (is.raw(path)) {
     return(list(rawConnection(path, "rb")))
   }
@@ -46,7 +46,9 @@ standardise_path <- function(path) {
     }
 
     if (any(grepl("\n", path))) {
-      lifecycle::deprecate_soft("1.5.0", "vroom(file = 'must use `I()` for literal data')",
+      lifecycle::deprecate_soft(
+        "1.5.0",
+        "vroom(file = 'must use `I()` for literal data')",
         details = c(
           "",
           "# Bad:",
@@ -54,7 +56,8 @@ standardise_path <- function(path) {
           "",
           "# Good:",
           "vroom(I(\"foo\\nbar\\n\"))"
-        )
+        ),
+        user_env = user_env()
       )
       return(list(chr_to_file(path, envir = parent.frame())))
     }

--- a/R/path.R
+++ b/R/path.R
@@ -50,12 +50,12 @@ standardise_path <- function(path, user_env = rlang::caller_env(2)) {
         "1.5.0",
         "vroom(file = 'must use `I()` for literal data')",
         details = c(
-          "",
-          "# Bad:",
-          "vroom(\"foo\\nbar\\n\")",
-          "",
-          "# Good:",
-          "vroom(I(\"foo\\nbar\\n\"))"
+          " " = "",
+          " " = "# Bad:",
+          " " = 'vroom("foo\\nbar\\n")',
+          " " = "",
+          " " = "# Good:",
+          " " = 'vroom(I("foo\\nbar\\n"))'
         ),
         user_env = user_env
       )

--- a/R/path.R
+++ b/R/path.R
@@ -57,7 +57,7 @@ standardise_path <- function(path, user_env = rlang::caller_env(2)) {
           "# Good:",
           "vroom(I(\"foo\\nbar\\n\"))"
         ),
-        user_env = user_env()
+        user_env = user_env
       )
       return(list(chr_to_file(path, envir = parent.frame())))
     }

--- a/R/path.R
+++ b/R/path.R
@@ -52,10 +52,10 @@ standardise_path <- function(path, user_env = rlang::caller_env(2)) {
         details = c(
           " " = "",
           " " = "# Bad:",
-          " " = 'vroom("foo\\nbar\\n")',
+          " " = 'vroom("X,Y\\n1.5,2.3\\n")',
           " " = "",
           " " = "# Good:",
-          " " = 'vroom(I("foo\\nbar\\n"))'
+          " " = 'vroom(I("X,Y\\n1.5,2.3\\n"))'
         ),
         user_env = user_env
       )

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -55,27 +55,6 @@ extern "C" SEXP _vroom_convert_connection(SEXP in_con, SEXP out_con, SEXP from, 
     return cpp11::as_sexp(convert_connection(cpp11::as_cpp<cpp11::decay_t<SEXP>>(in_con), cpp11::as_cpp<cpp11::decay_t<SEXP>>(out_con), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(from), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(to)));
   END_CPP11
 }
-// vroom.cc
-SEXP vroom_(const cpp11::list& inputs, SEXP delim, const char quote, bool trim_ws, bool escape_double, bool escape_backslash, const char* comment, const bool skip_empty_rows, size_t skip, ptrdiff_t n_max, bool progress, const cpp11::sexp& col_names, cpp11::sexp col_types, cpp11::sexp col_select, cpp11::sexp name_repair, SEXP id, const cpp11::strings& na, const cpp11::list& locale, ptrdiff_t guess_max, size_t num_threads, size_t altrep);
-extern "C" SEXP _vroom_vroom_(SEXP inputs, SEXP delim, SEXP quote, SEXP trim_ws, SEXP escape_double, SEXP escape_backslash, SEXP comment, SEXP skip_empty_rows, SEXP skip, SEXP n_max, SEXP progress, SEXP col_names, SEXP col_types, SEXP col_select, SEXP name_repair, SEXP id, SEXP na, SEXP locale, SEXP guess_max, SEXP num_threads, SEXP altrep) {
-  BEGIN_CPP11
-    return cpp11::as_sexp(vroom_(cpp11::as_cpp<cpp11::decay_t<const cpp11::list&>>(inputs), cpp11::as_cpp<cpp11::decay_t<SEXP>>(delim), cpp11::as_cpp<cpp11::decay_t<const char>>(quote), cpp11::as_cpp<cpp11::decay_t<bool>>(trim_ws), cpp11::as_cpp<cpp11::decay_t<bool>>(escape_double), cpp11::as_cpp<cpp11::decay_t<bool>>(escape_backslash), cpp11::as_cpp<cpp11::decay_t<const char*>>(comment), cpp11::as_cpp<cpp11::decay_t<const bool>>(skip_empty_rows), cpp11::as_cpp<cpp11::decay_t<size_t>>(skip), cpp11::as_cpp<cpp11::decay_t<ptrdiff_t>>(n_max), cpp11::as_cpp<cpp11::decay_t<bool>>(progress), cpp11::as_cpp<cpp11::decay_t<const cpp11::sexp&>>(col_names), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(col_types), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(col_select), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair), cpp11::as_cpp<cpp11::decay_t<SEXP>>(id), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(na), cpp11::as_cpp<cpp11::decay_t<const cpp11::list&>>(locale), cpp11::as_cpp<cpp11::decay_t<ptrdiff_t>>(guess_max), cpp11::as_cpp<cpp11::decay_t<size_t>>(num_threads), cpp11::as_cpp<cpp11::decay_t<size_t>>(altrep)));
-  END_CPP11
-}
-// vroom.cc
-bool has_trailing_newline(const cpp11::strings& filename);
-extern "C" SEXP _vroom_has_trailing_newline(SEXP filename) {
-  BEGIN_CPP11
-    return cpp11::as_sexp(has_trailing_newline(cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(filename)));
-  END_CPP11
-}
-// vroom.cc
-SEXP vroom_rle(const cpp11::integers& input);
-extern "C" SEXP _vroom_vroom_rle(SEXP input) {
-  BEGIN_CPP11
-    return cpp11::as_sexp(vroom_rle(cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(input)));
-  END_CPP11
-}
 // vroom_dttm.cc
 cpp11::writable::doubles utctime_(const cpp11::integers& year, const cpp11::integers& month, const cpp11::integers& day, const cpp11::integers& hour, const cpp11::integers& min, const cpp11::integers& sec, const cpp11::doubles& psec);
 extern "C" SEXP _vroom_utctime_(SEXP year, SEXP month, SEXP day, SEXP hour, SEXP min, SEXP sec, SEXP psec) {
@@ -125,6 +104,27 @@ cpp11::strings vroom_format_(const cpp11::list& input, const char delim, const s
 extern "C" SEXP _vroom_vroom_format_(SEXP input, SEXP delim, SEXP eol, SEXP na_str, SEXP col_names, SEXP append, SEXP options, SEXP num_threads, SEXP progress, SEXP buf_lines) {
   BEGIN_CPP11
     return cpp11::as_sexp(vroom_format_(cpp11::as_cpp<cpp11::decay_t<const cpp11::list&>>(input), cpp11::as_cpp<cpp11::decay_t<const char>>(delim), cpp11::as_cpp<cpp11::decay_t<const std::string&>>(eol), cpp11::as_cpp<cpp11::decay_t<const char*>>(na_str), cpp11::as_cpp<cpp11::decay_t<bool>>(col_names), cpp11::as_cpp<cpp11::decay_t<bool>>(append), cpp11::as_cpp<cpp11::decay_t<size_t>>(options), cpp11::as_cpp<cpp11::decay_t<size_t>>(num_threads), cpp11::as_cpp<cpp11::decay_t<bool>>(progress), cpp11::as_cpp<cpp11::decay_t<size_t>>(buf_lines)));
+  END_CPP11
+}
+// vroom.cc
+SEXP vroom_(const cpp11::list& inputs, SEXP delim, const char quote, bool trim_ws, bool escape_double, bool escape_backslash, const char* comment, const bool skip_empty_rows, size_t skip, ptrdiff_t n_max, bool progress, const cpp11::sexp& col_names, cpp11::sexp col_types, cpp11::sexp col_select, cpp11::sexp name_repair, SEXP id, const cpp11::strings& na, const cpp11::list& locale, ptrdiff_t guess_max, size_t num_threads, size_t altrep);
+extern "C" SEXP _vroom_vroom_(SEXP inputs, SEXP delim, SEXP quote, SEXP trim_ws, SEXP escape_double, SEXP escape_backslash, SEXP comment, SEXP skip_empty_rows, SEXP skip, SEXP n_max, SEXP progress, SEXP col_names, SEXP col_types, SEXP col_select, SEXP name_repair, SEXP id, SEXP na, SEXP locale, SEXP guess_max, SEXP num_threads, SEXP altrep) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(vroom_(cpp11::as_cpp<cpp11::decay_t<const cpp11::list&>>(inputs), cpp11::as_cpp<cpp11::decay_t<SEXP>>(delim), cpp11::as_cpp<cpp11::decay_t<const char>>(quote), cpp11::as_cpp<cpp11::decay_t<bool>>(trim_ws), cpp11::as_cpp<cpp11::decay_t<bool>>(escape_double), cpp11::as_cpp<cpp11::decay_t<bool>>(escape_backslash), cpp11::as_cpp<cpp11::decay_t<const char*>>(comment), cpp11::as_cpp<cpp11::decay_t<const bool>>(skip_empty_rows), cpp11::as_cpp<cpp11::decay_t<size_t>>(skip), cpp11::as_cpp<cpp11::decay_t<ptrdiff_t>>(n_max), cpp11::as_cpp<cpp11::decay_t<bool>>(progress), cpp11::as_cpp<cpp11::decay_t<const cpp11::sexp&>>(col_names), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(col_types), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(col_select), cpp11::as_cpp<cpp11::decay_t<cpp11::sexp>>(name_repair), cpp11::as_cpp<cpp11::decay_t<SEXP>>(id), cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(na), cpp11::as_cpp<cpp11::decay_t<const cpp11::list&>>(locale), cpp11::as_cpp<cpp11::decay_t<ptrdiff_t>>(guess_max), cpp11::as_cpp<cpp11::decay_t<size_t>>(num_threads), cpp11::as_cpp<cpp11::decay_t<size_t>>(altrep)));
+  END_CPP11
+}
+// vroom.cc
+bool has_trailing_newline(const cpp11::strings& filename);
+extern "C" SEXP _vroom_has_trailing_newline(SEXP filename) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(has_trailing_newline(cpp11::as_cpp<cpp11::decay_t<const cpp11::strings&>>(filename)));
+  END_CPP11
+}
+// vroom.cc
+SEXP vroom_rle(const cpp11::integers& input);
+extern "C" SEXP _vroom_vroom_rle(SEXP input) {
+  BEGIN_CPP11
+    return cpp11::as_sexp(vroom_rle(cpp11::as_cpp<cpp11::decay_t<const cpp11::integers&>>(input)));
   END_CPP11
 }
 

--- a/tests/testthat/_snaps/path.md
+++ b/tests/testthat/_snaps/path.md
@@ -7,10 +7,10 @@
       The `file` argument of `vroom()` must use `I()` for literal data as of vroom 1.5.0.
         
         # Bad:
-        vroom("foo\nbar\n")
+        vroom("X,Y\n1.5,2.3\n")
         
         # Good:
-        vroom(I("foo\nbar\n"))
+        vroom(I("X,Y\n1.5,2.3\n"))
 
 ---
 
@@ -21,8 +21,8 @@
       The `file` argument of `vroom()` must use `I()` for literal data as of vroom 1.5.0.
         
         # Bad:
-        vroom("foo\nbar\n")
+        vroom("X,Y\n1.5,2.3\n")
         
         # Good:
-        vroom(I("foo\nbar\n"))
+        vroom(I("X,Y\n1.5,2.3\n"))
 

--- a/tests/testthat/_snaps/path.md
+++ b/tests/testthat/_snaps/path.md
@@ -12,17 +12,3 @@
         # Good:
         vroom(I("X,Y\n1.5,2.3\n"))
 
----
-
-    Code
-      x <- f("a,b,c,d\n1,2,3,4")
-    Condition
-      Warning:
-      The `file` argument of `vroom()` must use `I()` for literal data as of vroom 1.5.0.
-        
-        # Bad:
-        vroom("X,Y\n1.5,2.3\n")
-        
-        # Good:
-        vroom(I("X,Y\n1.5,2.3\n"))
-

--- a/tests/testthat/_snaps/path.md
+++ b/tests/testthat/_snaps/path.md
@@ -1,0 +1,28 @@
+# vroom() informs user to use I() for literal data (or not)
+
+    Code
+      x <- vroom("a,b,c,d\n1,2,3,4", show_col_types = FALSE)
+    Condition
+      Warning:
+      The `file` argument of `vroom()` must use `I()` for literal data as of vroom 1.5.0.
+        
+        # Bad:
+        vroom("foo\nbar\n")
+        
+        # Good:
+        vroom(I("foo\nbar\n"))
+
+---
+
+    Code
+      x <- f("a,b,c,d\n1,2,3,4")
+    Condition
+      Warning:
+      The `file` argument of `vroom()` must use `I()` for literal data as of vroom 1.5.0.
+        
+        # Bad:
+        vroom("foo\nbar\n")
+        
+        # Good:
+        vroom(I("foo\nbar\n"))
+

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -65,11 +65,6 @@ test_that("vroom() informs user to use I() for literal data (or not)", {
   expect_snapshot(
     x <- vroom("a,b,c,d\n1,2,3,4", show_col_types = FALSE)
   )
-
-  f <- function(file) vroom(file, show_col_types = FALSE)
-  expect_snapshot(
-    x <- f("a,b,c,d\n1,2,3,4")
-  )
 })
 
 test_that("can write to a zip file if the archive package is available", {

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -61,6 +61,17 @@ test_that("split_path_ext works", {
   )
 })
 
+test_that("vroom() informs user to use I() for literal data (or not)", {
+  expect_snapshot(
+    x <- vroom("a,b,c,d\n1,2,3,4", show_col_types = FALSE)
+  )
+
+  f <- function(file) vroom(file, show_col_types = FALSE)
+  expect_snapshot(
+    x <- f("a,b,c,d\n1,2,3,4")
+  )
+})
+
 test_that("can write to a zip file if the archive package is available", {
   skip_on_cran()
   skip_if(!rlang::is_installed("archive"))


### PR DESCRIPTION
`details` will now be formatted with cli which causes this message to be width-wrapped, losing the newlines. With a future of cli, this sort of pattern will be made easier with "raw bullets".