### PR TITLE
Use .empty() method

### DIFF
--- a/src/vroom_write.cc
+++ b/src/vroom_write.cc
@@ -319,7 +319,7 @@ std::vector<char> get_header(
       out.push_back(delim);
     }
   }
-  if(out.size() != 0) {
+  if(!out.empty()) {
     if (delim != '\0') {
       out.pop_back();
     }


### PR DESCRIPTION
https://releases.llvm.org/5.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html