### PR TITLE
Simpler approach to `.conflicts.OK`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vroom
 Title: Read and Write Rectangular Text Data Quickly
-Version: 1.6.1.9000
+Version: 1.6.2
 Authors@R: c(
     person("Jim", "Hester", role = "aut",
            comment = c(ORCID = "0000-0002-2739-7082")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vroom
 Title: Read and Write Rectangular Text Data Quickly
-Version: 1.6.2
+Version: 1.6.2.9000
 Authors@R: c(
     person("Jim", "Hester", role = "aut",
            comment = c(ORCID = "0000-0002-2739-7082")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# vroom (development version)
+
 # vroom 1.6.2
 
 * No user-facing changes.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# vroom (development version)
+# vroom 1.6.2
 
 * No user-facing changes.
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -21,10 +21,7 @@
   }
 }
 
-.onAttach <- function(libname, pkgname) {
-  env <- as.environment(paste0("package:", pkgname))
-  env[[".conflicts.OK"]] <- TRUE
-}
+.conflicts.OK <- TRUE
 
 s3_register <- function(generic, class, method = NULL) {
   stopifnot(is.character(generic), length(generic) == 1)


### PR DESCRIPTION
Deciding how to respond to this new warning from CRAN's incoming Debian checks:

```
* using log directory ‘/srv/hornik/tmp/CRAN/vroom.Rcheck’
* using R Under development (unstable) (2023-04-27 r84336)
* using platform: x86_64-pc-linux-gnu (64-bit)
* R was compiled by
    Debian clang version 15.0.6
    GNU Fortran (Debian 12.2.0-14) 12.2.0
* running under: Debian GNU/Linux 12 (bookworm)
...
* checking for missing documentation entries ... WARNING
Undocumented code objects:
  ‘.conflicts.OK’
All user-level objects in a package should have documentation entries.
See chapter ‘Writing R documentation files’ in the ‘Writing R
Extensions’ manual.
```