### PR TITLE
CI run with older cpp11

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,7 +6,6 @@
 # usethis::use_github_action("check-standard") will install it.
 on:
   push:
-    branches: [main, master]
   pull_request:
     branches: [main, master]
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -80,3 +80,4 @@ Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
+Remotes: cran/cpp11@0.4.3


### PR DESCRIPTION
Don't merge this :) This is just to show that CI problems from the main branch disappear with an older cpp11.