### PR TITLE
Allow reading list of connections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vroom (development version)
 
+* It is now possible (again?) to read from a list of connections (@bairdj, #514).
+
 * Internal change for compatibility with cpp11 >= 0.4.6 (@DavisVaughan).
 
 # vroom 1.6.3

--- a/R/path.R
+++ b/R/path.R
@@ -27,7 +27,7 @@ standardise_path <- function(path, user_env = caller_env(2)) {
   }
 
   if (inherits(path, "connection")) {
-    return(list(path))
+    return(list(standardise_connection(path)))
   }
 
   if (is_list(path) && all(sapply(path, inherits, "connection"))) {

--- a/R/path.R
+++ b/R/path.R
@@ -27,14 +27,11 @@ standardise_path <- function(path, user_env = caller_env(2)) {
   }
 
   if (inherits(path, "connection")) {
-    # If the connection is `stdin()`, change it to `file("stdin")`, as we don't
-    # support text mode connections.
-
-    if (path == stdin()) {
-      return(list(file("stdin")))
-    }
-
     return(list(path))
+  }
+
+  if (is_list(path) && all(sapply(path, \(x) inherits(x, "connection")))) {
+    return(lapply(path, standardise_connection))
   }
 
   if (is.character(path)) {
@@ -64,6 +61,17 @@ standardise_path <- function(path, user_env = caller_env(2)) {
   }
 
   as.list(enc2utf8(path))
+}
+
+standardise_connection <- function(con) {
+  # If the connection is `stdin()`, change it to `file("stdin")`, as we don't
+  # support text mode connections.
+
+  if (con == stdin()) {
+    return(file("stdin"))
+  }
+
+  con
 }
 
 standardise_one_path <- function (path, write = FALSE) {

--- a/R/path.R
+++ b/R/path.R
@@ -30,7 +30,7 @@ standardise_path <- function(path, user_env = caller_env(2)) {
     return(list(path))
   }
 
-  if (is_list(path) && all(sapply(path, \(x) inherits(x, "connection")))) {
+  if (is_list(path) && all(sapply(path, inherits, "connection"))) {
     return(lapply(path, standardise_connection))
   }
 

--- a/tests/testthat/test-multi-file.R
+++ b/tests/testthat/test-multi-file.R
@@ -75,7 +75,7 @@ test_that("vroom works with many connections", {
   dir.create(dir)
   on.exit(unlink(dir, recursive = TRUE))
 
-  for (i in seq_len(200)) {
+  for (i in seq_len(20)) {
     vroom_write(
       tibble::tibble(
         x = rnorm(10),
@@ -87,11 +87,12 @@ test_that("vroom works with many connections", {
   }
 
   files <- list.files(dir, pattern = ".*[.]csv[.]gz", full.names = TRUE)
+  connections <- lapply(files, gzfile)
 
-  res <- vroom::vroom(files, col_types = list())
+  res <- vroom::vroom(connections, col_types = list())
 
   expect_equal(colnames(res), c("x", "y"))
-  expect_equal(NROW(res), 2000)
+  expect_equal(NROW(res), 200)
 })
 
 test_that("vroom errors if numbers of columns are inconsistent", {


### PR DESCRIPTION
Fixes #509 

This amends `standardise_path` to work with a list of connections, as referred to in the vignette.

The test for this functionality "vroom works with many connections" was incorrectly passing a character vector of paths to `vroom` instead of a list of connections, so this wasn't being picked up as a failing test.