### PR TITLE
Include missing headers

### DIFF
--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -4,6 +4,7 @@
 #include "vroom_types.h"
 #include "cpp11/declarations.hpp"
 #include <R_ext/Visibility.h>
+#include <cstddef>
 
 // altrep.cc
 void force_materialization(SEXP x);

--- a/src/cpp11.cpp
+++ b/src/cpp11.cpp
@@ -4,7 +4,6 @@
 #include "vroom_types.h"
 #include "cpp11/declarations.hpp"
 #include <R_ext/Visibility.h>
-#include <cstddef>
 
 // altrep.cc
 void force_materialization(SEXP x);

--- a/src/vroom_write.cc
+++ b/src/vroom_write.cc
@@ -1,5 +1,6 @@
 #include "grisu3.h"
 #include <array>
+#include <functional>
 #include <future>
 #include <iterator>
 


### PR DESCRIPTION
- cpp11.cpp: `<cstddef>` for `ptrdiff_t`
- vroom_write.cc: for `<functional>` `std::cref`

---

Our tooling also recommends directly including the following cpp11 headers to src/cpp11.cpp, but I omitted that as it feels more stylistic:

 - `"cpp11/as.hpp"` for `as_cpp` and `as_sexp`
 - `"cpp11/integers.hpp"` for `integers`

Happy to update the patch to include those if desired.