### PR TITLE
Add collector-level na support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,4 +79,4 @@ Copyright: file COPYRIGHTS
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3.9000
+RoxygenNote: 7.3.2

--- a/R/col_types.R
+++ b/R/col_types.R
@@ -32,6 +32,11 @@
 #' @param .delim The delimiter to use when parsing. If the `delim` argument
 #'   used in the call to `vroom()` it takes precedence over the one specified in
 #'   `col_types`.
+#' @param na Character vector of strings to interpret as missing values for the
+#'   column. If `NULL`, the column will use the missing values specified in the
+#'   `na` argument in the call to `vroom()`, otherwise, the missing values
+#'   specified here will take precedence. Set this option to `character()` to
+#'   indicate no missing values for the column.
 #' @export
 #' @aliases col_types
 #' @examples
@@ -207,7 +212,11 @@ format.col_spec <- function(x, n = Inf, condense = NULL, colour = crayon::has_co
     vapply(seq_along(cols),
       function(i) {
         col_funs <- sub("^collector_", "col_", class(cols[[i]])[[1]])
-        args <- vapply(cols[[i]], deparse2, character(1), sep = "\n    ")
+        args <- cols[[i]]
+        if (is.null(args[["na"]])) {
+          args[["na"]] <- NULL
+        }
+        args <- vapply(args, deparse2, character(1), sep = "\n    ")
         args <- paste(names(args), args, sep = " = ", collapse = ", ")
 
         col_funs <- paste0(col_funs, "(", args, ")")
@@ -624,32 +633,32 @@ color_type <- function(type) {
 
 #' @rdname cols
 #' @export
-col_logical <- function(...) {
-  collector("logical", ...)
+col_logical <- function(na = NULL, ...) {
+  collector("logical", na = na, ...)
 }
 
 #' @rdname cols
 #' @export
-col_integer <- function(...) {
-  collector("integer", ...)
+col_integer <- function(na = NULL, ...) {
+  collector("integer", na = na, ...)
 }
 
 #' @rdname cols
 #' @export
-col_big_integer <- function(...) {
-  collector("big_integer", ...)
+col_big_integer <- function(na = NULL, ...) {
+  collector("big_integer", na = na, ...)
 }
 
 #' @rdname cols
 #' @export
-col_double <- function(...) {
-  collector("double", ...)
+col_double <- function(na = NULL, ...) {
+  collector("double", na = na, ...)
 }
 
 #' @rdname cols
 #' @export
-col_character <- function(...) {
-  collector("character", ...)
+col_character <- function(na = NULL, ...) {
+  collector("character", na = na, ...)
 }
 
 #' @rdname cols
@@ -660,38 +669,38 @@ col_skip <- function(...) {
 
 #' @rdname cols
 #' @export
-col_number <- function(...) {
-  collector("number", ...)
+col_number <- function(na = NULL, ...) {
+  collector("number", na = na, ...)
 }
 
 #' @rdname cols
 #' @export
-col_guess <- function(...) {
-  collector("guess", ...)
+col_guess <- function(na = NULL, ...) {
+  collector("guess", na = na, ...)
 }
 
 #' @inheritParams readr::col_factor
 #' @rdname cols
 #' @export
-col_factor <- function(levels = NULL, ordered = FALSE, include_na = FALSE, ...) {
-  collector("factor", levels = levels, ordered = ordered, include_na = include_na, ...)
+col_factor <- function(levels = NULL, ordered = FALSE, include_na = FALSE, na = NULL, ...) {
+  collector("factor", levels = levels, ordered = ordered, include_na = include_na, na = na, ...)
 }
 
 #' @inheritParams readr::col_datetime
 #' @rdname cols
 #' @export
-col_datetime <- function(format = "", ...) {
-  collector("datetime", format = format, ...)
+col_datetime <- function(format = "", na = NULL, ...) {
+  collector("datetime", format = format, na = na, ...)
 }
 
 #' @rdname cols
 #' @export
-col_date <- function(format = "", ...) {
-  collector("date", format = format, ...)
+col_date <- function(format = "", na = NULL, ...) {
+  collector("date", format = format, na = na, ...)
 }
 
 #' @rdname cols
 #' @export
-col_time <- function(format = "", ...) {
-  collector("time", format = format, ...)
+col_time <- function(format = "", na = NULL, ...) {
+  collector("time", format = format, na = na, ...)
 }

--- a/R/generator.R
+++ b/R/generator.R
@@ -171,7 +171,9 @@ gen_tbl <- function(rows, cols = NULL, col_types = NULL, locale = default_locale
       specs$cols[[i]] <- do.call(paste0("col_", type), list())
     }
     fun_nme <- paste0("gen_", type)
-    res[[i]] <- do.call(fun_nme, c(rows, specs$cols[[i]]))
+    args <- specs$cols[[i]]
+    args[["na"]] <- NULL
+    res[[i]] <- do.call(fun_nme, c(rows, args))
   }
 
   if (missing > 0) {

--- a/man/cols.Rd
+++ b/man/cols.Rd
@@ -22,29 +22,29 @@ cols(..., .default = col_guess(), .delim = NULL)
 
 cols_only(...)
 
-col_logical(...)
+col_logical(na = NULL, ...)
 
-col_integer(...)
+col_integer(na = NULL, ...)
 
-col_big_integer(...)
+col_big_integer(na = NULL, ...)
 
-col_double(...)
+col_double(na = NULL, ...)
 
-col_character(...)
+col_character(na = NULL, ...)
 
 col_skip(...)
 
-col_number(...)
+col_number(na = NULL, ...)
 
-col_guess(...)
+col_guess(na = NULL, ...)
 
-col_factor(levels = NULL, ordered = FALSE, include_na = FALSE, ...)
+col_factor(levels = NULL, ordered = FALSE, include_na = FALSE, na = NULL, ...)
 
-col_datetime(format = "", ...)
+col_datetime(format = "", na = NULL, ...)
 
-col_date(format = "", ...)
+col_date(format = "", na = NULL, ...)
 
-col_time(format = "", ...)
+col_time(format = "", na = NULL, ...)
 }
 \arguments{
 \item{...}{Either column objects created by \verb{col_*()}, or their abbreviated
@@ -60,6 +60,12 @@ will be read with this column type.}
 \item{.delim}{The delimiter to use when parsing. If the \code{delim} argument
 used in the call to \code{vroom()} it takes precedence over the one specified in
 \code{col_types}.}
+
+\item{na}{Character vector of strings to interpret as missing values for the
+column. If \code{NULL}, the column will use the missing values specified in the
+\code{na} argument in the call to \code{vroom()}, otherwise, the missing values
+specified here will take precedence. Set this option to \code{character()} to
+indicate no missing values for the column.}
 
 \item{levels}{Character vector of the allowed levels. When \code{levels = NULL}
 (the default), \code{levels} are discovered from the unique values of \code{x}, in

--- a/man/vroom_fwf.Rd
+++ b/man/vroom_fwf.Rd
@@ -90,7 +90,7 @@ character represents one column:
 
 By default, reading a file without a column specification will print a
 message showing what \code{readr} guessed they were. To remove this message,
-set \code{show_col_types = FALSE} or set `options(readr.show_col_types = FALSE).}
+set \code{show_col_types = FALSE} or set \code{options(readr.show_col_types = FALSE)}.}
 
 \item{col_select}{Columns to include in the results. You can use the same
 mini-language as \code{dplyr::select()} to refer to the columns by name. Use
@@ -159,9 +159,11 @@ supported:
 \itemize{
 \item \code{"minimal"}: No name repair or checks, beyond basic existence of names.
 \item \code{"unique"} (default value): Make sure names are unique and not empty.
-\item \code{"check_unique"}: no name repair, but check they are \code{unique}.
+\item \code{"check_unique"}: No name repair, but check they are \code{unique}.
+\item \code{"unique_quiet"}: Repair with the \code{unique} strategy, quietly.
 \item \code{"universal"}: Make the names \code{unique} and syntactic.
-\item A function: apply custom name repair (e.g., \code{name_repair = make.names}
+\item \code{"universal_quiet"}: Repair with the \code{universal} strategy, quietly.
+\item A function: Apply custom name repair (e.g., \code{name_repair = make.names}
 for names in the style of base R).
 \item A purrr-style anonymous function, see \code{\link[rlang:as_function]{rlang::as_function()}}.
 }

--- a/src/columns.h
+++ b/src/columns.h
@@ -129,11 +129,14 @@ inline cpp11::list create_columns(
       continue;
     }
 
+    auto col_na = collector.na();
+    auto col_na_res = Rf_isNull(col_na) ? na : cpp11::strings(col_na);
+
     // This is deleted in the finalizers when the vectors are GC'd by R
     auto info = new vroom_vec_info{
         idx->get_column(col),
         num_threads,
-        std::make_shared<cpp11::strings>(na),
+        std::make_shared<cpp11::strings>(col_na_res),
         locale_info,
         *errors,
         std::string()};

--- a/tests/testthat/test-col-na.R
+++ b/tests/testthat/test-col-na.R
@@ -1,0 +1,16 @@
+test_that("collector-level na overrides global na", {
+  test_vroom(
+    "a,b,c\na,foo,REFUSED\nb,REFUSED,NA\nOMITTED,bar,OMITTED\n",
+    col_types = cols(
+      a = col_character(na = "OMITTED"),
+      b = col_character(na = "REFUSED"),
+      c = col_character()
+    ),
+    na = "NA",
+    equals = tibble::tibble(
+      a = c("a", "b", NA),
+      b = c("foo", NA, "bar"),
+      c = c("REFUSED", NA, "OMITTED"),
+    )
+  )
+})


### PR DESCRIPTION
This PR adds support for collector-level `na` args (#532). This way, different lists of missing values can be specified for each column, overriding the global `na` arg in the call to `vroom()`.

Example:

``` r
vroom(
  I("a,b,c\na,foo,REFUSED\nb,REFUSED,MISSING\nOMITTED,bar,OMITTED\n"),
  col_types = cols(
    a = col_character(na = "OMITTED"),
    b = col_character(na = "REFUSED"),
    c = col_character()
  ),
  na = "MISSING"
)
#> # A tibble: 3 × 3
#>   a     b     c      
#>   <chr> <chr> <chr>  
#> 1 a     foo   REFUSED
#> 2 b     NA    NA     
#> 3 NA    bar   OMITTED
```

Without this PR, it is very difficult to efficiently read columns with different lists of missing values. Instead, they have to be loaded as character vectors, then parsed with `readr::parse_*()` or `readr::type_convert()`. There are two problems with this:

- parsing a chr vector after loading with vroom forces the vector to materialize, defeating vroom's lazy-loading altrep goodness
- vroom & readr's parsing rules have slightly diverged in subtle ways (e.g. https://github.com/tidyverse/readr/issues/1526)

I'm hoping you'll consider this PR for inclusion to vroom – it only requires a few changes, is 100% backwards compatible, and adds a feature that cannot otherwise be implemented in a separate package (without duplicating all of vroom's internals). Please let me know if there is anything more I can do to advocate for it. Thank you for your consideration!