### PR TITLE
Avoid implicit conversion from `sexp` to `bool`

### DIFF
--- a/src/iconv_file.cc
+++ b/src/iconv_file.cc
@@ -1,4 +1,5 @@
 #include <cerrno>
+#include <cpp11/as.hpp>
 #include <cpp11/R.hpp>
 
 #include "R_ext/Riconv.h"
@@ -23,8 +24,8 @@
   size_t insize = 0;
   void* cd;
 
-  bool should_close_in = !isOpen(in_con);
-  bool should_close_out = !isOpen(out_con);
+  bool should_close_in = !cpp11::as_cpp<bool>(isOpen(in_con));
+  bool should_close_out = !cpp11::as_cpp<bool>(isOpen(out_con));
 
   if (should_close_in) {
     open(in_con, "rb");


### PR DESCRIPTION
cpp11 allows some somewhat scary implicit conversions between `sexp` and the 3 types `bool`, `size_t`, and `double`. These are unchecked conversions, and we'd like to remove them:
https://github.com/r-lib/cpp11/pull/390/

The recommended way is to use `cpp11::as_cpp<bool>()`, which checks the type and length before performing the conversion.

I'm not going to remove these in this version of cpp11, but we will in the next