### PR TITLE
Fix for ALTREP crash in base R CHARSXP use-after-free

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vroom (development version)
 
+* `vroom()` now keeps individually accessed strings from lazy character columns alive across later allocations.
+
 # vroom 1.7.1
 
 * Internal changes requested by CRAN for forward compatibility with clang 22.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # vroom (development version)
 
-* `vroom()` now keeps individually accessed strings from lazy character columns alive across later allocations.
+* Fixed a use-after-free crash when base R held an element of a lazy character column across an allocation. Accessed strings are now retained for the lifetime of the column, so element-wise passes over lazy character columns may use more memory than before. (@traversc, #638)
 
 # vroom 1.7.1
 

--- a/src/vroom_chr.cc
+++ b/src/vroom_chr.cc
@@ -12,6 +12,34 @@ SEXP check_na(SEXP na, SEXP val) {
   return val;
 }
 
+void fill_chr(vroom_vec_info* info, SEXP out) {
+  SEXP nas = *info->na;
+
+  cpp11::unwind_protect([&] {
+    auto i = 0;
+    auto col = info->column;
+    for (auto b = col->begin(), e = col->end(); b != e; ++b) {
+      if (STRING_ELT(out, i) != R_BlankString) {
+        ++i;
+        continue;
+      }
+
+      auto str = *b;
+      auto val = info->locale->encoder_.makeSEXP(str.begin(), str.end(), true);
+      PROTECT(val);
+      if (Rf_xlength(val) < str.end() - str.begin()) {
+        info->errors->add_error(
+            b.index(), col->get_index(), "", "embedded null", b.filename());
+      }
+
+      SET_STRING_ELT(out, i++, check_na(nas, val));
+      UNPROTECT(1);
+    }
+  });
+
+  info->errors->warn_for_errors();
+}
+
 cpp11::strings read_chr(vroom_vec_info* info) {
 
   R_xlen_t n = info->column->size();

--- a/src/vroom_chr.cc
+++ b/src/vroom_chr.cc
@@ -1,5 +1,7 @@
 #include "vroom_chr.h"
 
+static void copy_cached_chr(SEXP cache, SEXP out);
+
 SEXP check_na(SEXP na, SEXP val) {
   for (R_xlen_t i = 0; i < Rf_xlength(na); ++i) {
     SEXP v = STRING_ELT(na, i);
@@ -12,15 +14,26 @@ SEXP check_na(SEXP na, SEXP val) {
   return val;
 }
 
+cpp11::strings read_chr(vroom_vec_info* info, SEXP cache) {
+
+  R_xlen_t n = info->column->size();
+
+  cpp11::writable::strings out(n);
+
+  copy_cached_chr(cache, out);
+  fill_chr(info, out);
+
+  return out;
+}
+
 void fill_chr(vroom_vec_info* info, SEXP out) {
   SEXP nas = *info->na;
 
   cpp11::unwind_protect([&] {
-    auto i = 0;
+    R_xlen_t i = 0;
     auto col = info->column;
-    for (auto b = col->begin(), e = col->end(); b != e; ++b) {
+    for (auto b = col->begin(), e = col->end(); b != e; ++b, ++i) {
       if (STRING_ELT(out, i) != R_BlankString) {
-        ++i;
         continue;
       }
 
@@ -32,7 +45,7 @@ void fill_chr(vroom_vec_info* info, SEXP out) {
             b.index(), col->get_index(), "", "embedded null", b.filename());
       }
 
-      SET_STRING_ELT(out, i++, check_na(nas, val));
+      SET_STRING_ELT(out, i, check_na(nas, val));
       UNPROTECT(1);
     }
   });
@@ -40,34 +53,29 @@ void fill_chr(vroom_vec_info* info, SEXP out) {
   info->errors->warn_for_errors();
 }
 
-cpp11::strings read_chr(vroom_vec_info* info) {
+// Copy strings cached by vroom_chr::string_Elt() into `out`, so that
+// materializing does not parse them a second time.
+static void copy_cached_chr(SEXP cache, SEXP out) {
+  if (cache == R_NilValue) {
+    return;
+  }
 
-  R_xlen_t n = info->column->size();
-
-  cpp11::writable::strings out(n);
-
-  SEXP nas = *info->na;
-
-  cpp11::unwind_protect([&] {
-    auto i = 0;
-    auto col = info->column;
-    for (auto b = col->begin(), e = col->end(); b != e; ++b) {
-      auto str = *b;
-      auto val = info->locale->encoder_.makeSEXP(str.begin(), str.end(), true);
-      PROTECT(val);
-      if (Rf_xlength(val) < str.end() - str.begin()) {
-        info->errors->add_error(
-            b.index(), col->get_index(), "", "embedded null", b.filename());
-      }
-
-      SET_STRING_ELT(out, i++, check_na(nas, val));
-      UNPROTECT(1);
+  R_xlen_t n_chunks = Rf_xlength(cache);
+  for (R_xlen_t c = 0; c < n_chunks; ++c) {
+    SEXP chunk = VECTOR_ELT(cache, c);
+    if (chunk == R_NilValue) {
+      continue;
     }
-  });
 
-  info->errors->warn_for_errors();
-
-  return out;
+    R_xlen_t offset = c << vroom_chr::chunk_shift;
+    R_xlen_t len = Rf_xlength(chunk);
+    for (R_xlen_t j = 0; j < len; ++j) {
+      SEXP val = STRING_ELT(chunk, j);
+      if (val != R_BlankString) {
+        SET_STRING_ELT(out, offset + j, val);
+      }
+    }
+  }
 }
 
 R_altrep_class_t vroom_chr::class_t;

--- a/src/vroom_chr.h
+++ b/src/vroom_chr.h
@@ -8,6 +8,7 @@
 #include "vroom_vec.h"
 
 cpp11::strings read_chr(vroom_vec_info* info);
+void fill_chr(vroom_vec_info* info, SEXP out);
 SEXP check_na(SEXP na, SEXP val);
 
 struct vroom_chr : vroom_vec {
@@ -45,6 +46,20 @@ public:
 
   // ALTSTRING methods -----------------
 
+  // Keep strings created by string_Elt() reachable through data1. New
+  // STRSXPs contain R_BlankString, which serves as the cache miss marker.
+  // Empty strings share this permanent singleton and do not need rooting.
+  static SEXP EltCache(SEXP vec) {
+    SEXP ptr = R_altrep_data1(vec);
+    SEXP cache = R_ExternalPtrProtected(ptr);
+    if (cache == nullptr || TYPEOF(cache) != STRSXP) {
+      cache = PROTECT(Rf_allocVector(STRSXP, Length(vec)));
+      R_SetExternalPtrProtected(ptr, cache);
+      UNPROTECT(1);
+    }
+    return cache;
+  }
+
   static SEXP Val(SEXP vec, R_xlen_t i) {
     auto& info = Info(vec);
 
@@ -80,7 +95,16 @@ public:
     }
     SPDLOG_TRACE("{0:x}: vroom_chr string_Elt {1}", (size_t)vec, i);
 
-    return Val(vec, i);
+    SEXP cache = EltCache(vec);
+    SEXP val = STRING_ELT(cache, i);
+    if (val == R_BlankString) {
+      val = PROTECT(Val(vec, i));
+      if (val != R_BlankString) {
+        SET_STRING_ELT(cache, i, val);
+      }
+      UNPROTECT(1);
+    }
+    return val;
   }
 
   // --- Altvec
@@ -91,12 +115,22 @@ public:
     }
 
     SPDLOG_TRACE("{0:x}: vroom_chr Materialize", (size_t)vec);
+    SEXP data1 = R_altrep_data1(vec);
+    SEXP cache = R_ExternalPtrProtected(data1);
+    if (cache != nullptr && TYPEOF(cache) == STRSXP) {
+      fill_chr(&Info(vec), cache);
+      R_set_altrep_data2(vec, cache);
+
+      // Once we have materialized we no longer need the cache or info
+      R_SetExternalPtrProtected(data1, R_NilValue);
+      Finalize(data1);
+
+      return cache;
+    }
+
     auto out = read_chr(&Info(vec));
     R_set_altrep_data2(vec, out);
-
-    // Once we have materialized we no longer need the info
-    Finalize(R_altrep_data1(vec));
-
+    Finalize(data1);
     return out;
   }
 

--- a/src/vroom_chr.h
+++ b/src/vroom_chr.h
@@ -124,7 +124,7 @@ public:
     }
     SPDLOG_TRACE("{0:x}: vroom_chr string_Elt {1}", (size_t)vec, i);
 
-    SEXP chunk = EltChunk(vec, i);
+    SEXP chunk = PROTECT(EltChunk(vec, i));
     R_xlen_t j = i & chunk_mask;
     SEXP val = STRING_ELT(chunk, j);
     if (val == R_BlankString) {
@@ -132,6 +132,7 @@ public:
       SET_STRING_ELT(chunk, j, val);
       UNPROTECT(1);
     }
+    UNPROTECT(1);
 
     return val;
   }

--- a/src/vroom_chr.h
+++ b/src/vroom_chr.h
@@ -7,14 +7,30 @@
 #include "r_utils.h"
 #include "vroom_vec.h"
 
-cpp11::strings read_chr(vroom_vec_info* info);
+// Allocate and parse a full character vector for `info`, reusing any strings
+// already cached by vroom_chr::string_Elt() (see vroom_chr::EltChunk).
+cpp11::strings read_chr(vroom_vec_info* info, SEXP cache = R_NilValue);
+
+// Parse into `out` every element that is still R_BlankString.
 void fill_chr(vroom_vec_info* info, SEXP out);
+
 SEXP check_na(SEXP na, SEXP val);
 
 struct vroom_chr : vroom_vec {
 
 public:
   static R_altrep_class_t class_t;
+
+  // Strings created by string_Elt() must stay reachable for as long as the
+  // vector does, because R may hold a pointer from STRING_ELT() across a
+  // later allocation. They are kept in fixed-size STRSXP chunks hanging off
+  // a VECSXP in the external pointer's protected slot. Chunks are allocated
+  // on first touch, so sparse access costs one chunk rather than a
+  // full-length vector. Within a chunk, R_BlankString marks a miss: empty
+  // strings share that permanent singleton and need no rooting.
+  static constexpr R_xlen_t chunk_shift = 10;
+  static constexpr R_xlen_t chunk_size = R_xlen_t(1) << chunk_shift;
+  static constexpr R_xlen_t chunk_mask = chunk_size - 1;
 
   // Make an altrep object of class `stdvec_double::class_t`
   static SEXP Make(vroom_vec_info* info) {
@@ -46,20 +62,6 @@ public:
 
   // ALTSTRING methods -----------------
 
-  // Keep strings created by string_Elt() reachable through data1. New
-  // STRSXPs contain R_BlankString, which serves as the cache miss marker.
-  // Empty strings share this permanent singleton and do not need rooting.
-  static SEXP EltCache(SEXP vec) {
-    SEXP ptr = R_altrep_data1(vec);
-    SEXP cache = R_ExternalPtrProtected(ptr);
-    if (cache == nullptr || TYPEOF(cache) != STRSXP) {
-      cache = PROTECT(Rf_allocVector(STRSXP, Length(vec)));
-      R_SetExternalPtrProtected(ptr, cache);
-      UNPROTECT(1);
-    }
-    return cache;
-  }
-
   static SEXP Val(SEXP vec, R_xlen_t i) {
     auto& info = Info(vec);
 
@@ -70,7 +72,7 @@ public:
         PROTECT(info.locale->encoder_.makeSEXP(str.begin(), str.end(), true));
 
     if (Rf_xlength(val) < str.end() - str.begin()) {
-      auto&& itr = info.column->begin();
+      auto itr = col->begin() + i;
       info.errors->add_error(
           itr.index(), col->get_index(), "", "embedded null", itr.filename());
     }
@@ -84,6 +86,33 @@ public:
     return val;
   }
 
+  // The cache chunk holding element `i`, allocating it (and the chunk
+  // vector) on first use.
+  static SEXP EltChunk(SEXP vec, R_xlen_t i) {
+    SEXP ptr = R_altrep_data1(vec);
+    SEXP chunks = R_ExternalPtrProtected(ptr);
+    if (chunks == R_NilValue) {
+      R_xlen_t n_chunks = (Length(vec) + chunk_mask) >> chunk_shift;
+      chunks = PROTECT(Rf_allocVector(VECSXP, n_chunks));
+      R_SetExternalPtrProtected(ptr, chunks);
+      UNPROTECT(1);
+    }
+
+    R_xlen_t c = i >> chunk_shift;
+    SEXP chunk = VECTOR_ELT(chunks, c);
+    if (chunk == R_NilValue) {
+      R_xlen_t len = Length(vec) - (c << chunk_shift);
+      if (len > chunk_size) {
+        len = chunk_size;
+      }
+      chunk = PROTECT(Rf_allocVector(STRSXP, len));
+      SET_VECTOR_ELT(chunks, c, chunk);
+      UNPROTECT(1);
+    }
+
+    return chunk;
+  }
+
   // the element at the index `i`
   //
   // this does not do bounds checking because that's expensive, so
@@ -95,15 +124,15 @@ public:
     }
     SPDLOG_TRACE("{0:x}: vroom_chr string_Elt {1}", (size_t)vec, i);
 
-    SEXP cache = EltCache(vec);
-    SEXP val = STRING_ELT(cache, i);
+    SEXP chunk = EltChunk(vec, i);
+    R_xlen_t j = i & chunk_mask;
+    SEXP val = STRING_ELT(chunk, j);
     if (val == R_BlankString) {
       val = PROTECT(Val(vec, i));
-      if (val != R_BlankString) {
-        SET_STRING_ELT(cache, i, val);
-      }
+      SET_STRING_ELT(chunk, j, val);
       UNPROTECT(1);
     }
+
     return val;
   }
 
@@ -116,21 +145,13 @@ public:
 
     SPDLOG_TRACE("{0:x}: vroom_chr Materialize", (size_t)vec);
     SEXP data1 = R_altrep_data1(vec);
-    SEXP cache = R_ExternalPtrProtected(data1);
-    if (cache != nullptr && TYPEOF(cache) == STRSXP) {
-      fill_chr(&Info(vec), cache);
-      R_set_altrep_data2(vec, cache);
-
-      // Once we have materialized we no longer need the cache or info
-      R_SetExternalPtrProtected(data1, R_NilValue);
-      Finalize(data1);
-
-      return cache;
-    }
-
-    auto out = read_chr(&Info(vec));
+    auto out = read_chr(&Info(vec), R_ExternalPtrProtected(data1));
     R_set_altrep_data2(vec, out);
+
+    // Once we have materialized we no longer need the cache or the info
+    R_SetExternalPtrProtected(data1, R_NilValue);
     Finalize(data1);
+
     return out;
   }
 

--- a/tests/testthat/test-chr.R
+++ b/tests/testthat/test-chr.R
@@ -35,3 +35,35 @@ test_that("encodings are respected", {
   )
   expect_equal(x[[1]], expected)
 })
+
+test_that("ALTREP character elements stay alive across allocations", {
+  path <- withr::local_tempfile()
+  # Use raw bytes so no ordinary character vector keeps the input string alive.
+  writeBin(
+    as.raw(c(0x69L, rep.int(0x30L, 6L), 0x31L, 0x0aL)),
+    path
+  )
+  input <- vroom(
+    path,
+    delim = ",",
+    col_names = FALSE,
+    col_types = cols(X1 = col_character()),
+    altrep = "chr",
+    num_threads = 1L,
+    progress = FALSE,
+    show_col_types = FALSE
+  )[[1L]]
+
+  target_value <- rawToChar(as.raw(c(0xe9L, rep.int(0x78L, 6L))))
+  Encoding(target_value) <- "latin1"
+  target <- rep.int(target_value, 256L)
+
+  gctorture(TRUE)
+  withr::defer(gctorture(FALSE))
+  first <- charmatch(input, target, nomatch = NA_integer_)
+  second <- charmatch(input, target, nomatch = NA_integer_)
+  gctorture(FALSE)
+
+  expect_identical(first, NA_integer_)
+  expect_identical(second, NA_integer_)
+})

--- a/tests/testthat/test-chr.R
+++ b/tests/testthat/test-chr.R
@@ -67,3 +67,67 @@ test_that("ALTREP character elements stay alive across allocations", {
   expect_identical(first, NA_integer_)
   expect_identical(second, NA_integer_)
 })
+
+test_that("ALTREP character problems report the correct row", {
+  path <- withr::local_tempfile()
+  writeBin(
+    as.raw(c(
+      0x61L, 0x0aL,
+      0x62L, 0x0aL,
+      0x63L, 0x00L, 0x64L, 0x0aL
+    )),
+    path
+  )
+
+  x <- vroom(
+    path,
+    delim = ",",
+    col_names = FALSE,
+    col_types = "c",
+    altrep = "chr",
+    num_threads = 1L,
+    progress = FALSE,
+    show_col_types = FALSE
+  )
+
+  expect_warning(x[[1L]][[3L]], class = "vroom_parse_issue")
+
+  # The problem is recorded correctly before materialization.
+  expect_equal(problems(x, lazy = TRUE)$row, 3)
+
+  # `problems()` materializes by default. Cached values must not cause the
+  # incorrect row to reappear or the correct row to be lost.
+  expect_equal(problems(x)$row, 3)
+})
+
+test_that("partially cached ALTREP character vectors materialize correctly", {
+  n <- 2500L
+  expected <- sprintf("v%04d", seq_len(n))
+  expected[c(3L, 1025L)] <- ""
+  expected[c(4L, 1026L)] <- NA_character_
+
+  path <- withr::local_tempfile()
+  # Quote the empty strings so that they are not skipped as empty rows.
+  lines <- ifelse(expected == "", '""', expected)
+  writeLines(ifelse(is.na(lines), "NA", lines), path)
+
+  x <- vroom(
+    path,
+    delim = ",",
+    col_names = FALSE,
+    col_types = "c",
+    na = "NA",
+    altrep = "chr",
+    num_threads = 1L,
+    progress = FALSE,
+    show_col_types = FALSE
+  )[[1L]]
+
+  # Touch the first, middle and last chunks, including the empty and NA
+  # elements, so that materializing has to merge cached and uncached chunks.
+  idx <- c(1L, 3L, 4L, 1024L, 1025L, 1026L, 2049L, n)
+  expect_identical(vapply(idx, function(i) x[[i]], ""), expected[idx])
+
+  vroom_materialize(list(x), replace = FALSE)
+  expect_identical(x, expected)
+})

--- a/tests/testthat/test-chr.R
+++ b/tests/testthat/test-chr.R
@@ -100,6 +100,51 @@ test_that("ALTREP character problems report the correct row", {
   expect_equal(problems(x)$row, 3)
 })
 
+test_that("ALTREP character Elt survives re-entrant materialization", {
+  skip_on_os("windows")
+
+  path <- withr::local_tempfile()
+  writeBin(
+    as.raw(c(
+      0x61L, 0x0aL,
+      0x62L, 0x0aL,
+      0x63L, 0x00L, 0x64L, 0x0aL
+    )),
+    path
+  )
+
+  x <- vroom(
+    path,
+    delim = ",",
+    col_names = FALSE,
+    col_types = "c",
+    altrep = "chr",
+    num_threads = 1L,
+    progress = FALSE,
+    show_col_types = FALSE
+  )
+  col <- x[[1L]]
+
+  value <- withCallingHandlers(
+    col[[3L]],
+    vroom_parse_issue = function(cnd) {
+      # Change the mapped bytes before materializing from the warning handler.
+      con <- file(path, "r+b")
+      seek(con, where = 4L, origin = "start", rw = "write")
+      writeBin(charToRaw("xyz"), con)
+      close(con)
+
+      problems(x)
+      invokeRestart("muffleWarning")
+    }
+  )
+
+  # The in-flight Elt() returns the value parsed before re-entry, while the
+  # materialized vector reflects the modified backing bytes.
+  expect_identical(value, "c")
+  expect_identical(col[[3L]], "xyz")
+})
+
 test_that("partially cached ALTREP character vectors materialize correctly", {
   n <- 2500L
   expected <- sprintf("v%04d", seq_len(n))

--- a/tests/testthat/test-chr.R
+++ b/tests/testthat/test-chr.R
@@ -100,51 +100,6 @@ test_that("ALTREP character problems report the correct row", {
   expect_equal(problems(x)$row, 3)
 })
 
-test_that("ALTREP character Elt survives re-entrant materialization", {
-  skip_on_os("windows")
-
-  path <- withr::local_tempfile()
-  writeBin(
-    as.raw(c(
-      0x61L, 0x0aL,
-      0x62L, 0x0aL,
-      0x63L, 0x00L, 0x64L, 0x0aL
-    )),
-    path
-  )
-
-  x <- vroom(
-    path,
-    delim = ",",
-    col_names = FALSE,
-    col_types = "c",
-    altrep = "chr",
-    num_threads = 1L,
-    progress = FALSE,
-    show_col_types = FALSE
-  )
-  col <- x[[1L]]
-
-  value <- withCallingHandlers(
-    col[[3L]],
-    vroom_parse_issue = function(cnd) {
-      # Change the mapped bytes before materializing from the warning handler.
-      con <- file(path, "r+b")
-      seek(con, where = 4L, origin = "start", rw = "write")
-      writeBin(charToRaw("xyz"), con)
-      close(con)
-
-      problems(x)
-      invokeRestart("muffleWarning")
-    }
-  )
-
-  # The in-flight Elt() returns the value parsed before re-entry, while the
-  # materialized vector reflects the modified backing bytes.
-  expect_identical(value, "c")
-  expect_identical(col[[3L]], "xyz")
-})
-
 test_that("partially cached ALTREP character vectors materialize correctly", {
   n <- 2500L
   expected <- sprintf("v%04d", seq_len(n))


### PR DESCRIPTION
Here is a link to a reproducible example of the crash (tested on Linux and Mac) https://gist.github.com/traversc/4e04e761dc020bf4a47693e444bf73c4

### The issue
`vroom_chr::string_Elt()` returns newly created CHARSXPs without keeping them reachable from the source ALTREP vector. A later allocation could therefore collect an element while base R code still held its pointer, which is a Use-After-Free.

I know that this was discussed before and is by design. So arguably this could be considered a base R bug but I think the fix is better placed in package because the fix:

1) also makes vroom faster and more efficient overall.
2) makes ALTREP and non-ALTREP strings semantically equal (so less footgun-y for Rcpp/cpp11 scripts)

### The fix
The fix suggested by Claude (Fable) is to keep individually accessed strings in a STRSXP cache attached to the external pointer's "protected" slot. When the vector is materialized, the cache is promoted to `data2` and only its missing elements are filled.

It looks like the "protected" slot `R_SetExternalPtrProtected` is exactly for this kind of thing, to keep R data alive that the external pointer needs.

This ends up being more efficient, because the materialization work for individual elements only happens once. You don't re-process individual CHARSXPs when you materialize the whole vector or access them again.

A previous issue: https://github.com/gagolews/stringi/issues/354
